### PR TITLE
[#180283604] Consul SystemD Logrotate Fixes

### DIFF
--- a/templates/etc/logrotate.d/consul.j2
+++ b/templates/etc/logrotate.d/consul.j2
@@ -5,8 +5,5 @@
 	missingok
 	notifempty
 	compress
-	compresscmd /bin/bzip2
-	uncompresscmd /bin/bunzip2
-	compressext .bz2
 	copytruncate
 }

--- a/templates/etc/systemd/system/consul.service.j2
+++ b/templates/etc/systemd/system/consul.service.j2
@@ -12,13 +12,13 @@ Group=consul
 EnvironmentFile=-/etc/default/{{ _consul.service_name }}
 # Der Parameter '-config-dir' muss gesetzt sein, ansonsten startet der Consul Client nicht
 # Sofern der User keine DAEMON_ARGS gesetzt hat, sorgt die folgende Zeile dafür, dass zumindest
-# ein default Wert gesetzt ist, mit dem der Consul Client starten kann. 
+# ein default Wert gesetzt ist, mit dem der Consul Client starten kann.
 Environment=DAEMON_ARGS="-config-dir={{ _consul.config_dir }}"
 ExecStart=/usr/local/bin/consul agent $DAEMON_ARGS $CONSUL_FLAGS
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 LimitNOFILE=65536
-StandardOutput=file:{{ _consul.logfile }}
+StandardOutput=append:{{ _consul.logfile }}
 StandardError=inherit
 
 [Install]

--- a/templates/etc/systemd/system/consul.service.j2
+++ b/templates/etc/systemd/system/consul.service.j2
@@ -18,8 +18,8 @@ ExecStart=/usr/local/bin/consul agent $DAEMON_ARGS $CONSUL_FLAGS
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 LimitNOFILE=65536
-# Es wird explizit "append" statt "file" genutzt da ansonsten nach dem Logrotate unleserliche Zeichen
-# im Logfile entstehen, siehe auch: https://github.com/CenterDevice/ops/issues/262
+# Es wird explizit "append" statt "file" genutzt, da ansonsten nach dem Logrotate binäre Zeichenketten
+# "@^@^@^@^.." im Logfile entstehen, siehe auch: https://github.com/CenterDevice/ops/issues/262
 StandardOutput=append:{{ _consul.logfile }}
 StandardError=inherit
 

--- a/templates/etc/systemd/system/consul.service.j2
+++ b/templates/etc/systemd/system/consul.service.j2
@@ -18,6 +18,8 @@ ExecStart=/usr/local/bin/consul agent $DAEMON_ARGS $CONSUL_FLAGS
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 LimitNOFILE=65536
+# Es wird explizit "append" statt "file" genutzt da ansonsten nach dem Logrotate unleserliche Zeichen
+# im Logfile entstehen, siehe auch: https://github.com/CenterDevice/ops/issues/262
 StandardOutput=append:{{ _consul.logfile }}
 StandardError=inherit
 


### PR DESCRIPTION
- alte Logs werden nun mit gzip komprimiert nach der Rotation
- StandardOutput= `append` statt `file` als Fix für https://github.com/CenterDevice/ops/issues/262 
- Whitespace in Zeile 15 entfernt